### PR TITLE
Fix/add express session

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
+    "@types/express-session": "1.17.0",
     "@types/mocha": "^9.1.0",
     "@types/pouchdb-core": "^7.0.10",
     "axios": "^0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,7 +537,15 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.13":
+"@types/express-session@1.17.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.17.0.tgz#770daf81368f6278e3e40dd894e1e52abbdca0cd"
+  integrity sha512-OQEHeBFE1UhChVIBhRh9qElHUvTp4BzKKHxMDkGHT7WuYk5eL93hPG7D8YAIkoBSbhNEY0RjreF15zn+U0eLjA==
+  dependencies:
+    "@types/express" "*"
+    "@types/node" "*"
+
+"@types/express@*", "@types/express@^4.17.13":
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.13.tgz#a76e2995728999bab51a33fabce1d705a3709034"
   integrity sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==


### PR DESCRIPTION
`yarn build` fails with error:

```
src/controller.ts:64:13 - error TS2339: Property 'session' does not exist on type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>'.

64         req.session.did = did
               ~~~~~~~


Found 1 error in src/controller.ts
```

Added `express-session` and downgraded express typescript types as per https://dev.to/qoobes/express-session-failing-with-typescript-types-express-session-1ehk