### PR TITLE
Fix common unit test to config pagination

### DIFF
--- a/src/providers/google/README.md
+++ b/src/providers/google/README.md
@@ -26,9 +26,9 @@ Before running the unit tests, ensure that you have the following set up:
 1. **YouTube Account**: A YouTube account with some activity is required. This activity includes uploaded videos, subscriptions, and liked videos.
 
 2. **YouTube Data**: Make sure your YouTube account has:
-   - **Favorites**: At least 14 videos you have liked.
-   - **Following**: At least 14 Channels you have subscribed to.
-   - **Posts**: At least 14 videos you have uploaded.
+   - **Favorites**: At least 4 videos you have liked.
+   - **Following**: At least 4 Channels you have subscribed to.
+   - **Posts**: At least 4 videos you have uploaded.
 3. **Activity**: Make sure you have made activities within the last 24 hours.
 
 ## Running the Tests

--- a/src/web/developer/data/data.js
+++ b/src/web/developer/data/data.js
@@ -238,8 +238,8 @@ $(document).ready(function() {
             "File": "https://common.schemas.verida.io/file/v0.1.0/schema.json",
             "Chat Group": "https://common.schemas.verida.io/social/chat/group/v0.1.0/schema.json",
             "Chat Message": "https://common.schemas.verida.io/social/chat/message/v0.1.0/schema.json",
-            "CALENDAR": "https://common.schemas.verida.io/social/calendar/v0.1.0/schema.json",
-            "EVENT": "https://common.schemas.verida.io/social/event/v0.1.0/schema.json"
+            "Calendar": "https://common.schemas.verida.io/social/calendar/v0.1.0/schema.json",
+            "Event": "https://common.schemas.verida.io/social/event/v0.1.0/schema.json"
         };
 
         // Clear previous list


### PR DESCRIPTION
Closes #103 

Added optional parameters to config page number and item number per page with default value of 2.
So, you need to have at least 4 items to pass unit tests now.