### PR TITLE
Fix access check on DID mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@verida/encryption-utils": "^4.0.0",
     "@verida/helpers": "^4.3.0",
     "@verida/types": "^4.3.0",
+    "@verida/vda-common": "^4.3.0",
     "@verida/vda-sbt-client": "^4.3.0",
     "@verida/verifiable-credentials": "^4.3.0",
     "@verida/web3": "^4.3.0",

--- a/src/api/rest/v1/access/types.ts
+++ b/src/api/rest/v1/access/types.ts
@@ -20,7 +20,7 @@ export type GetAccessV1ErrorResponse = ErrorResponse & {
 
 export type AccessRecord = {
   id: string;
-  did: string;
+  didAddress: string;
   admin: boolean;
   access: boolean;
 }

--- a/src/api/rest/v1/access/utils.ts
+++ b/src/api/rest/v1/access/utils.ts
@@ -112,7 +112,7 @@ export function transformNotionRecordToAccessRecord(record: DatabaseObjectRespon
 
   return {
     id: record.id,
-    did: getValueFromNotionTitleProperty(properties["DID"]),
+    didAddress: getValueFromNotionTitleProperty(properties["DID"]),
     admin: getValueFromNotionCheckboxProperty(properties["Admin"]),
     access: getValueFromNotionCheckboxProperty(properties["Access"]),
   }

--- a/src/api/rest/v1/access/utils.ts
+++ b/src/api/rest/v1/access/utils.ts
@@ -1,6 +1,7 @@
 import { Request } from "express";
 import { Client as NotionClient } from "@notionhq/client";
 import { DatabaseObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import { interpretIdentifier } from "@verida/vda-common";
 
 import { AccessRecord } from "./types";
 import { NotionDatabaseProperty } from "./notion-types";
@@ -35,6 +36,8 @@ export async function createAccessRecord(notionClient: NotionClient, did: string
     return
   }
 
+  const didAddress = interpretIdentifier(did).address
+
   try {
     await notionClient.pages.create({
       parent: {
@@ -46,7 +49,7 @@ export async function createAccessRecord(notionClient: NotionClient, did: string
           type: "title",
           title: [{
             type: "text",
-            text: { content: did }
+            text: { content: didAddress }
           }],
         },
         Admin: {
@@ -72,13 +75,15 @@ export async function getAccessRecord(notionClient: NotionClient, did: string): 
     throw new Error("Notion restricted access database ID is not set")
   }
 
+  const didAddress = interpretIdentifier(did).address
+
   try {
     const response = await notionClient.databases.query({
       database_id: serverconfig.notion.restrictedAccessDatabaseId,
       filter: {
         property: "DID",
         rich_text: {
-          equals: did,
+          equals: didAddress
         },
       },
     })

--- a/src/api/rest/v1/access/utils.ts
+++ b/src/api/rest/v1/access/utils.ts
@@ -36,8 +36,6 @@ export async function createAccessRecord(notionClient: NotionClient, did: string
     return
   }
 
-  const didAddress = interpretIdentifier(did).address
-
   try {
     await notionClient.pages.create({
       parent: {
@@ -49,7 +47,7 @@ export async function createAccessRecord(notionClient: NotionClient, did: string
           type: "title",
           title: [{
             type: "text",
-            text: { content: didAddress }
+            text: { content: did }
           }],
         },
         Admin: {
@@ -83,7 +81,7 @@ export async function getAccessRecord(notionClient: NotionClient, did: string): 
       filter: {
         property: "DID",
         rich_text: {
-          equals: didAddress
+          contains: didAddress
         },
       },
     })


### PR DESCRIPTION
Instead of checking the DID with different network/blockchain id, I store the DID address only in Notion, so it make it easier.

That way, we should avoid duplicates of the same DID (could happen with same DID for different network/blockchain id)